### PR TITLE
Emitting "Key not found" error now an Error object

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -73,7 +73,7 @@ module.exports = class Downloader extends EventEmitter {
                 else {
                     if(!data || !data.Contents || data.Contents.length === 0) {
                         debug('key not found bucket: ' + self._s3Params.Bucket + ', Key: ' + self._s3Params.Key);
-                        return self.emit('error', 'Key not found');
+                        return self.emit('error', new Error('Key not found'));
                     }
                     else {
                         self.totalObjectSize = data.Contents[0].Size;


### PR DESCRIPTION
The error used to just be a string, lacking Error properties, like stack, etc.